### PR TITLE
bigquery sdk v0.23+ compatible patch

### DIFF
--- a/lib/embulk/input/bigquery.rb
+++ b/lib/embulk/input/bigquery.rb
@@ -77,7 +77,7 @@ module Embulk
         rows = if @task[:job_id].nil?
                  bq.query(@task[:sql], **option)
                else
-                 bq.job(@task[:job_id]).data(max: option[:max])
+                 bq.job(@task[:job_id]).query_results(max: option[:max])
                end
 
         @task[:columns] = values_to_sym(@task[:columns], 'name')


### PR DESCRIPTION
when define columns automatically, does not work with using BigQuery SDK v0.28-.
because call methods that has been implemented on v0.29.

this patch is fixed to call methods with v0.28- compatibility.

- not use QueryJob#data not implemented on sdk v0.28-
   - it has beed Added on following commit. (tag: google-cloud-bigquery/v0.29.0)
   - https://github.com/GoogleCloudPlatform/google-cloud-ruby/commit/f09343bc0f571e9a05053e81bc9481afdda4d5df#diff-258bcf19a8b19a54fbd2421f6a23dec7R220

- instead, use QueryJob#query_results available in v0.28- and v0.29+
   - https://github.com/GoogleCloudPlatform/google-cloud-ruby/commit/f7cfeef04f86fe67c853b55e0fa4646fc87e7e14
   > Alias to QueryJob#data
   - this method has backward compatibility