### PR TITLE
fix page result loop each to all

### DIFF
--- a/lib/embulk/input/bigquery.rb
+++ b/lib/embulk/input/bigquery.rb
@@ -82,7 +82,7 @@ module Embulk
 
         @task[:columns] = values_to_sym(@task[:columns], 'name')
 
-        rows.each do |row|
+        rows.all do |row|
           columns = []
           @task[:columns].each do |c|
             val = row[c['name'].to_sym]


### PR DESCRIPTION
thank you for this plugin. 
but i have problem with this plugin. rows.each just get only first page of result. 
when I run this plugin to get over 100,000 rows in query result, page result has NEXT PAGE TOKEN. then, i have to get all page result.  referance : https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/google-cloud-bigquery/v0.29.0/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
have to change  each -> all

ps, determine_columns_by_query_results is very useful!! thank you.