### PR TITLE
allow google-cloud-bigquery versions between  0.24 and up to 1.11.x

### DIFF
--- a/embulk-input-bigquery.gemspec
+++ b/embulk-input-bigquery.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'google-cloud-bigquery', ['>= 0.24', '< 1.5.0']
+  spec.add_dependency 'google-cloud-bigquery', ['>= 0.24', '< 1.12']
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
 end


### PR DESCRIPTION
Incompatible changes are not included

https://github.com/googleapis/google-cloud-ruby/blob/master/google-cloud-bigquery/CHANGELOG.md