### PR TITLE
add sql_file option to read SQL statement from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,23 @@ in:
   type: bigquery
   project: 'project-name'
   keyfile: '/home/hogehoge/bigquery-keyfile.json'
-  sql_erb: 'SELECT price,category_id FROM [ecsite.products_<%= params["date"].strftime("%Y%m")  %>] GROUP BY category_id'
+  sql_erb: 'select price,category_id from [ecsite.products_<%= params["date"].strftime("%y%m")  %>] group by category_id'
   erb_params:
-    date: "require 'date'; (Date.today - 1)"
+    date: "require 'date'; (date.today - 1)"
   columns:
     - {name: price, type: long}
     - {name: category_id, type: long}
-    - {name: month, type: timestamp, format: '%Y-%m', eval: 'require "time"; Time.parse(params["date"]).to_i'}
+    - {name: month, type: timestamp, format: '%y-%m', eval: 'require "time"; time.parse(params["date"]).to_i'}
+```
+
+If using SQL statement in the file, then
+
+```
+in:
+  type: bigquery
+  project: 'project-name'
+  keyfile: '/home/hogehoge/bigquery-keyfile.json'
+  sql_file: '/path/to/sql_file.sql'
 ```
 
 ## Authentication

--- a/lib/embulk/input/bigquery.rb
+++ b/lib/embulk/input/bigquery.rb
@@ -25,13 +25,18 @@ module Embulk
         params = {}
         unless sql
           sql_erb = config[:sql_erb]
-          erb = ERB.new(sql_erb)
-          erb_params = config[:erb_params] || {}
-          erb_params.each do |k, v|
-            params[k] = eval(v)
-          end
+          if sql_erb
+            erb = ERB.new(sql_erb)
+            erb_params = config[:erb_params] || {}
+            erb_params.each do |k, v|
+              params[k] = eval(v)
+            end
 
-          sql = erb.result(binding)
+            sql = erb.result(binding)
+          else
+            sql_file = config[:sql_file]
+            sql = File.open(sql_file) { |f| f.read }
+          end
         end
 
         task = {


### PR DESCRIPTION
I have problem that SQL statement with comment like below causes an error.
This YAML is invalid because YAML parser also treat a line starting with `#` as comment.
So, I propose adding `sql_file` option to read SQL statement from file.

```
in:
  sql:
    SELECT *
    # this is a  SQL comment
    FROM `my_project.my_dataset.my_table`
```

```
while parsing a block mapping
 in 'string', line 2, column 3:
      sql:
      ^
expected <block end>, but found Scalar
 in 'string', line 5, column 5:
        FROM `my_project.my_dataset.my_t ...
        ^

	at org.yaml.snakeyaml.parser.ParserImpl$ParseBlockMappingKey.produce(ParserImpl.java:569)
	at org.yaml.snakeyaml.parser.ParserImpl.peekEvent(ParserImpl.java:157)
	at org.yaml.snakeyaml.parser.ParserImpl.checkEvent(ParserImpl.java:147)
	at org.yaml.snakeyaml.composer.Composer.composeMappingNode(Composer.java:224)
	at org.yaml.snakeyaml.composer.Composer.composeNode(Composer.java:154)
	at org.yaml.snakeyaml.composer.Composer.composeValueNode(Composer.java:246)
	at org.yaml.snakeyaml.composer.Composer.composeMappingChildren(Composer.java:237)
	at org.yaml.snakeyaml.composer.Composer.composeMappingNode(Composer.java:225)
	at org.yaml.snakeyaml.composer.Composer.composeNode(Composer.java:154)
	at org.yaml.snakeyaml.composer.Composer.composeDocument(Composer.java:122)
	at org.yaml.snakeyaml.composer.Composer.getSingleNode(Composer.java:105)
	at org.yaml.snakeyaml.constructor.BaseConstructor.getSingleData(BaseConstructor.java:122)
	at org.yaml.snakeyaml.Yaml.loadFromReader(Yaml.java:505)
	at org.yaml.snakeyaml.Yaml.load(Yaml.java:424)
	at org.embulk.config.ConfigLoader.fromYamlString(ConfigLoader.java:58)
	at org.embulk.EmbulkRunner.readConfig(EmbulkRunner.java:359)
	at org.embulk.EmbulkRunner.run(EmbulkRunner.java:150)
	at org.embulk.cli.EmbulkRun.runSubcommand(EmbulkRun.java:436)
	at org.embulk.cli.EmbulkRun.run(EmbulkRun.java:91)
	at org.embulk.cli.Main.main(Main.java:26)

Error: while parsing a block mapping
 in 'string', line 2, column 3:
      sql:
      ^
expected <block end>, but found Scalar
 in 'string', line 5, column 5:
        FROM `my_project.my_dataset.my_t ...
        ^
```

