### PR TITLE
Stick google-cloud-env and google-cloud-core version. Because they require Ruby 2.4 or later at recent release.

### DIFF
--- a/embulk-input-bigquery.gemspec
+++ b/embulk-input-bigquery.gemspec
@@ -19,11 +19,15 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   # TODO
-  # signet 0.12.0 and google-api-client 0.33.0 require >= Ruby 2.4.
+  # signet 0.12.0, google-api-client 0.33.0
+  # google-cloud-env 1.3.0 and google-cloud-core 1.4.0 "require >= Ruby 2.4.
   # Embulk 0.9 use JRuby 9.1.X.Y and It compatible Ruby 2.3.
-  # So, Force install signet < 0.12 and google-api-client < 0.33.0
+  # So, Force install signet < 0.12, google-api-client < 0.33.0
+  # google-cloud-env 1.3.0 and google-cloud-core 1.4.0
   spec.add_dependency 'signet', '~> 0.7', '< 0.12.0'
   spec.add_dependency 'google-api-client','< 0.33.0'
+  spec.add_dependency 'google-cloud-env','< 1.3.0'
+  spec.add_dependency 'google-cloud-core','< 1.4.0'
   spec.add_dependency 'google-cloud-bigquery', ['>= 1.2', '< 1.12']
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
I started to use `embulk-input-bigquery` but install failed with following message.

```
$ embulk gem install embulk-input-bigquery
2019-10-29 22:24:29.069 +0900: Embulk v0.9.19

Gem plugin path is: /Users/noissefnoc/.embulk/lib/gems

Fetching: google-cloud-env-1.3.0.gem (100%)
ERROR:  Error installing embulk-input-bigquery:
	google-cloud-env requires Ruby version >= 2.4.
```

As you note in `embulk-input-bigquery.gemspec`, embulk 0.9 uses JRuby 9.1.X.Y (which is compatible with Ruby 2.3).

I checked [googleapis/google-cloud-ruby](https://github.com/googleapis/google-cloud-ruby) and found they require Ruby 2.4 or later at recent release.

* `google-cloud-env` ([CHANGELOG](https://github.com/googleapis/google-cloud-ruby/blob/master/google-cloud-env/CHANGELOG.md#130--2019-10-23))
    * Requires Ruby 2.4 or later at `1.3.0` / 2019-10-23
* `google-cloud-core` ([CHANGELOG](https://github.com/googleapis/google-cloud-ruby/blob/master/google-cloud-core/CHANGELOG.md#140--2019-10-23))
    * Requires Ruby 2.4 or later at `1.4.0` /  2019-10-23

I checked out codes,  added dependency in `embulk-input-bigquery.gemspec` and built gem.
And then gem install succeeded.

Could you check it?
(I'm sorry that I haven't tested this gem yet, just install.)


Followings are my operation log.

* Setup build environment (follows `README.md` "Develop" section)
```
$ embulk bundle install --path vendor/bundle
2019-10-29 22:49:00.414 +0900: Embulk v0.9.19
Fetching gem metadata from https://rubygems.org/.........
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies.....
(Omission)
Fetching google-api-client 0.32.1
Installing google-api-client 0.32.1
Fetching google-cloud-env 1.2.1
Installing google-cloud-env 1.2.1
Fetching google-cloud-core 1.3.2
Installing google-cloud-core 1.3.2
Fetching mime-types-data 3.2019.1009
Installing mime-types-data 3.2019.1009
Fetching mime-types 3.3
Installing mime-types 3.3
Fetching google-cloud-bigquery 1.11.2
Installing google-cloud-bigquery 1.11.2
Using embulk-input-bigquery 0.0.8 from source at `.`
Bundle complete! 3 Gemfile dependencies, 27 gems now installed.
Bundled gems are installed into `./vendor/bundle`
```

* Build gem
```
$ bundle exec rake build
embulk-input-bigquery 0.0.8 built to pkg/embulk-input-bigquery-0.0.8.gem.
```

* Install gem from local file
```
$ embulk gem install pkg/embulk-input-bigquery-0.0.8.gem
2019-10-29 22:57:34.802 +0900: Embulk v0.9.19

Gem plugin path is: /Users/noissefnoc/.embulk/lib/gems

Fetching: google-cloud-env-1.2.1.gem (100%)
Successfully installed google-cloud-env-1.2.1
Fetching: google-cloud-core-1.3.2.gem (100%)
Successfully installed google-cloud-core-1.3.2
Fetching: google-cloud-bigquery-1.11.2.gem (100%)
Successfully installed google-cloud-bigquery-1.11.2
Successfully installed embulk-input-bigquery-0.0.8
4 gems installed
```

* Check installed and version
```
$ embulk gem list | egrep 'bigquery|google-cloud'
embulk-input-bigquery (0.0.8)
google-cloud-bigquery (1.11.2)
google-cloud-core (1.3.2)
google-cloud-env (1.2.1)
``` 