### PR TITLE
Allow Google::Cloud::Bigquery to be initialised with extra options

### DIFF
--- a/lib/embulk/input/bigquery.rb
+++ b/lib/embulk/input/bigquery.rb
@@ -51,7 +51,7 @@ module Embulk
         if config[:columns]
           task[:columns] = config[:columns]
         else
-          bq = Google::Cloud::Bigquery.new(project: task[:project], keyfile: task[:keyfile])
+          bq = Google::Cloud::Bigquery.new(project: task[:project], keyfile: task[:keyfile], timeout: 1800)
           task[:job_id], task[:columns] = determine_columns_by_query_results(sql, task[:option], bq)
         end
 
@@ -70,7 +70,7 @@ module Embulk
       end
 
       def run
-        bq = Google::Cloud::Bigquery.new(project: task[:project], keyfile: task[:keyfile])
+        bq = Google::Cloud::Bigquery.new(project: task[:project], keyfile: task[:keyfile], timeout: 1800)
         params = @task[:params]
         option = keys_to_sym(@task[:option])
 

--- a/lib/embulk/input/bigquery.rb
+++ b/lib/embulk/input/bigquery.rb
@@ -20,11 +20,6 @@ module Embulk
         end
       end
 
-      def self.bigquery_client_factory(config)
-        bq_opts = {project: config.fetch(:project), keyfile: config.fetch(:keyfile)}.merge(task.fetch(:bigquery_opts, {}))
-        Google::Cloud::Bigquery.new(**bq_opts)
-      end
-
       def self.transaction(config, &control)
         sql = config[:sql]
         params = {}
@@ -50,14 +45,13 @@ module Embulk
             standard_sql: config[:standard_sql],
             legacy_sql: config[:legacy_sql],
             location: config[:location],
-          },
-          bigquery_opts: config.fetch(:bigquery_opts, {})
+          }
         }
 
         if config[:columns]
           task[:columns] = config[:columns]
         else
-          bq = bigquery_client_factory(task)
+          bq = Google::Cloud::Bigquery.new(project: task[:project], keyfile: task[:keyfile])
           task[:job_id], task[:columns] = determine_columns_by_query_results(sql, task[:option], bq)
         end
 
@@ -76,7 +70,7 @@ module Embulk
       end
 
       def run
-        bq = self.class.bigquery_client_factory(@task)
+        bq = Google::Cloud::Bigquery.new(project: task[:project], keyfile: task[:keyfile])
         params = @task[:params]
         option = keys_to_sym(@task[:option])
 


### PR DESCRIPTION
e.g. pass `bigquery_opts: {timeout: 3600}` to set a general timeout for the Bigquery client.

```yaml
in:
  type: bigquery
  project: google-123abc
  keyfile: secrets/service-account-json.json
  bigquery_opts: {timeout: 3600}
```